### PR TITLE
gemspec: Drop has_rdoc, rubyforge_project

### DIFF
--- a/image_voodoo.gemspec
+++ b/image_voodoo.gemspec
@@ -13,13 +13,10 @@ Gem::Specification.new do |s|
   s.summary     = 'Image manipulation in JRuby with ImageScience compatible API'
   s.description = 'Image manipulation in JRuby with ImageScience compatible API'
 
-  s.rubyforge_project = 'image_voodoo'
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = %w[lib vendor]
-  s.has_rdoc      = true
 
   s.add_development_dependency 'jar-dependencies'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436